### PR TITLE
Fix: Correct Vercel KV database connection

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,11 +17,9 @@ app = Flask(__name__)
 CORS(app)
 
 # Initialize Redis Client
-# Use the environment variables provided by Vercel KV
-redis = Redis(
-    url=os.environ.get('KV_URL'),
-    token=os.environ.get('KV_REST_API_TOKEN')
-)
+# The from_env() method automatically uses the Vercel KV environment variables
+# for the REST API (UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN).
+redis = Redis.from_env()
 
 JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'default-super-secret-key-for-testing')
 


### PR DESCRIPTION
This commit resolves a critical bug where the application would fail to connect to the Vercel KV (Redis) database due to an `UnsupportedProtocol` error.

The error occurred because the `upstash-redis` client was being initialized with a `rediss://` URL from the `KV_URL` environment variable, which is not supported by the HTTP-based library.

The fix replaces the manual client initialization with `Redis.from_env()`. This method is provided by the `upstash-redis` SDK and is the recommended way to connect in a Vercel environment, as it automatically uses the correct REST API environment variables (`UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`).